### PR TITLE
Adjust normalization handling

### DIFF
--- a/scripts/computeVariantsDistances.py
+++ b/scripts/computeVariantsDistances.py
@@ -986,7 +986,7 @@ def preprocess_vcf(job, graph, options):
             run("cp {} {}".format(output_vcf + ".qpct", output_vcf))
     
 
-    if options.normalize is True and options.tags[graph][2] not in ["gatk3", "platypus", "freebayes", "samtools", "g1kvcf", "platvcf", "platvcf-baseline"]:
+    if options.normalize is True:# and options.tags[graph][2] not in ["gatk3", "platypus", "freebayes", "samtools", "g1kvcf", "platvcf", "platvcf-baseline"]:
         # run blocksub (only on single allelic)
         sts = run("bcftools filter -e \"N_ALT > 1\" {} | vt decompose_blocksub -a - > {}".format( 
             output_vcf,

--- a/scripts/vcfQualStats.py
+++ b/scripts/vcfQualStats.py
@@ -56,11 +56,14 @@ in 5th column of vcf """
             qual = get_qual_from_line(line, None)
             if qual not in counts:
                 counts[qual] = [0, 0, 0]
-            # makes most sense for single allelic , normalized vcfs
-            if all(len(alt) == 1 and len(ref) == 1 for alt in alts):
+            # count any site where no length change as snp
+            # (rely on normalization to help divide these up)
+            if all(len(alt) == len(ref) for alt in alts):
                 counts[qual][0] += 1
-            elif all(len(alt) != len(ref) for alt in alts):
+            # and aynthing else an indel
+            elif any(len(alt) != len(ref) for alt in alts):
                 counts[qual][1] += 1
+            # deprecated for now
             else:
                 counts[qual][2] += 1
                     


### PR DESCRIPTION
These changes are to fix Platypus and Freebayes, which weren't getting the same normalization as everyone else. 
- Activate normalization (now just decompose blocksub on single alleles) on all VCFs. 
- Count block sub calls as SNPs.  So now Total = SNPS + Indels
